### PR TITLE
Temporarily remove martin et al 07 measurement of boo i

### DIFF
--- a/data/Bootes_(I).json
+++ b/data/Bootes_(I).json
@@ -98,14 +98,6 @@
             "best": 1,
             "unit": "km/s",
             "reference": "Koposov_2011"
-        },
-        {
-            "value": 6.5,
-            "error_upper": 2.1,
-            "error_lower": 1.3,
-            "best": 0,
-            "unit": "km/s",
-            "reference": "Martin_2007"
         }
     ]
 }


### PR DESCRIPTION
This PR removes the second measurement for Boo I that I added in #20  - the idea is we will make a PR with this commit: https://github.com/eteq/DSII_LocalGroupDB/commit/fa58ef7bc3be00ac936ef7f8d1d9ddbb7cfddb1b during the presentation to add in the new measurement.